### PR TITLE
Report active status when the charm is ready, rename charm to redis-k8s

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-name: redis
+name: redis-k8s
 summary: |
   Redis is an open source (BSD licensed), in-memory data
   structure store, used as a database, cache and message broker.

--- a/reactive/redis.py
+++ b/reactive/redis.py
@@ -4,6 +4,11 @@ from charms.reactive import when, when_not
 from charms import layer
 
 
+@when('charm.redis.started')
+def charm_ready():
+    layer.status.active('')
+
+
 @when('layer.docker-resource.redis-image.changed')
 def update_image():
     clear_flag('charm.redis.started')


### PR DESCRIPTION
When charm has pushed the pod spec, report status as active so juju can correctly reflect the unit status when the container has started.

Also, rename the charm to redis-k8s to avoid confusion with the iaas redis charm.